### PR TITLE
goombas will now face the other direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ FreeBSD:
 OS X (brew):
 
     $ brew install cmake sdl2 sdl2_image sdl2_mixer
+    
+Ubuntu:
+
+    $ sudo apt-get install cmake libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev
 
 ## Building and running
 

--- a/uNext/AboutMenu.h
+++ b/uNext/AboutMenu.h
@@ -19,7 +19,7 @@ private:
 	int iNumOfUnits;
 public:
 	AboutMenu(void);
-	~AboutMenu(void);
+	virtual ~AboutMenu(void);
 
 	void Update();
 	void Draw(SDL_Renderer* rR);

--- a/uNext/Cheep.cpp
+++ b/uNext/Cheep.cpp
@@ -38,7 +38,7 @@ Cheep::Cheep(int iXPos, int iYPos, int minionType, int moveSpeed, bool moveDirec
 		moveYDIR = true;
 	}
 	
-	this->collisionOnlyWithPlayer = true;
+	this->collisionOnlyWithPlayer = false;
 }
 
 Cheep::~Cheep(void) {
@@ -48,6 +48,9 @@ Cheep::~Cheep(void) {
 /* ******************************************** */
 
 void Cheep::Update() {
+	if(minionState != -2){
+
+
 	if(minionState == 0 || minionState == 1) {
 		if(fXPos + iHitBoxX < 0) {
 			minionState = -1;
@@ -151,6 +154,14 @@ void Cheep::Update() {
 			}
 		}
 	}
+	}
+	else
+	{
+		//moveYDIR = false;
+		//this->jumpDistance = CCFG::GAME_HEIGHT - fYPos;
+		Minion::minionDeathAnimation();
+
+	}
 }
 
 void Cheep::Draw(SDL_Renderer* rR, CIMG* iIMG) {
@@ -166,6 +177,11 @@ void Cheep::Draw(SDL_Renderer* rR, CIMG* iIMG) {
 void Cheep::minionPhysics() { }
 
 void Cheep::collisionWithPlayer(bool TOP) {
+	if(CCore::getMap()->getPlayer()->getStarEffect()) {
+
+		setMinionState(-2);
+	}
+
 	if(minionState > 1 && TOP) {
 		setMinionState(-2);
 		this->minionState = -2;

--- a/uNext/Event.cpp
+++ b/uNext/Event.cpp
@@ -346,7 +346,7 @@ void Event::newLevel() {
 		CCFG::getMM()->getLoadingMenu()->updateTime();
 		CCFG::getMM()->getLoadingMenu()->loadingType = true;
 		CCFG::getMM()->setViewID(CCFG::getMM()->eGameLoading);
-		CCore::getMap()->getPlayer()->setCoins(0);
+		//CCore::getMap()->getPlayer()->setCoins(0);
 	}
 	CCore::getMap()->setCurrentLevelID(newCurrentLevel);
 	CCore::getMap()->setLevelType(newLevelType);

--- a/uNext/Goombas.cpp
+++ b/uNext/Goombas.cpp
@@ -29,7 +29,7 @@ void Goombas::Update() {
 
 void Goombas::Draw(SDL_Renderer* rR, CIMG* iIMG) {
 	if(minionState != -2) {
-		iIMG->Draw(rR, (int)fXPos + (int)CCore::getMap()->getXPos(), (int)fYPos + 2, false);
+		iIMG->Draw(rR, (int)fXPos + (int)CCore::getMap()->getXPos(), (int)fYPos + 2, !moveDirection);
 	} else {
 		iIMG->DrawVert(rR, (int)fXPos + (int)CCore::getMap()->getXPos(), (int)fYPos + 2);
 	}

--- a/uNext/LoadingMenu.h
+++ b/uNext/LoadingMenu.h
@@ -11,7 +11,7 @@ private:
 	unsigned int iTime;
 public:
 	LoadingMenu(void);
-	~LoadingMenu(void);
+	virtual ~LoadingMenu(void);
 
 	void Update();
 	void Draw(SDL_Renderer* rR);

--- a/uNext/MainMenu.h
+++ b/uNext/MainMenu.h
@@ -14,7 +14,7 @@ private:
 	SDL_Rect rSelectWorld;
 public:
 	MainMenu(void);
-	~MainMenu(void);
+	virtual ~MainMenu(void);
 
 	void Update();
 	void Draw(SDL_Renderer* rR);

--- a/uNext/Map.cpp
+++ b/uNext/Map.cpp
@@ -558,7 +558,14 @@ int Map::checkCollisionWithPlatform(int nX, int nY, int iHitBoxX, int iHitBoxY) 
 }
 
 bool Map::checkCollision(Vector2* nV, bool checkVisible) {
-	bool output = vBlock[lMap[nV->getX()][nV->getY()]->getBlockID()]->getCollision() && (checkVisible ? vBlock[lMap[nV->getX()][nV->getY()]->getBlockID()]->getVisible() : true);
+	int x = nV->getX();
+	int lMapSize = lMap.size();
+	
+	if(lMapSize  <= x  ){
+		x = lMapSize -1;
+	}
+	
+	bool output = vBlock[lMap[x][nV->getY()]->getBlockID()]->getCollision() && (checkVisible ? vBlock[lMap[x][nV->getY()]->getBlockID()]->getVisible() : true);
 	delete nV;
 	return output;
 }

--- a/uNext/Minion.h
+++ b/uNext/Minion.h
@@ -11,7 +11,7 @@ class Minion
 {
 public:
 	Minion(void);
-	~Minion(void);
+	virtual ~Minion(void);
 
 	int minionState;
 

--- a/uNext/Player.cpp
+++ b/uNext/Player.cpp
@@ -366,6 +366,14 @@ void Player::Update() {
 			--nextFireBallFrameID;
 		}
 	}
+	
+		if (getCoins() > 99 ){
+			setNumOfLives(getNumOfLives() + 1);
+			CCore::getMap()->addPoints((int)(fXPos - CCore::getMap()->getXPos() + getHitBoxX() / 2), (int)fYPos + 16, "1UP", 10, 14);
+			CCFG::getMusic()->PlayChunk(CCFG::getMusic()->cONEUP);
+			setCoins(0);
+
+		}	
 
 	if(inLevelDownAnimation) {
 		if(inLevelDownAnimationFrameID > 0) {

--- a/uNext/Squid.cpp
+++ b/uNext/Squid.cpp
@@ -20,7 +20,7 @@ Squid::Squid(int iXPos, int iYPos) {
 	this->moveXDistance = 96;
 	this->moveYDistance = 32;
 
-	this->collisionOnlyWithPlayer = true;
+	this->collisionOnlyWithPlayer = false;
 
 	srand((unsigned)time(NULL));
 }
@@ -33,6 +33,7 @@ Squid::~Squid(void) {
 
 void Squid::Update() {
 	if(CCore::getMap()->getUnderWater()) {
+		if(minionState != -2){
 		if(moveXDistance <= 0) {
 			if(moveYDistance > 0) {
 				fYPos += 1;
@@ -61,12 +62,26 @@ void Squid::Update() {
 				changeBlockID();
 				moveYDistance = 32;
 			}
+
+
+			}
+		}
+		else {
+			Minion::minionDeathAnimation();
 		}
 	}
 }
 
 void Squid::Draw(SDL_Renderer* rR, CIMG* iIMG) {
-	iIMG->Draw(rR,(int)(fXPos + CCore::getMap()->getXPos()), (int)fYPos);
+	if(minionState != -2)
+	{
+		iIMG->Draw(rR,(int)(fXPos + CCore::getMap()->getXPos()), (int)fYPos);
+
+	}
+	else
+	{
+		iIMG->DrawVert(rR, (int)fXPos + (int)CCore::getMap()->getXPos(), (int)fYPos + 2);
+	}
 }
 
 void Squid::minionPhysics() { }
@@ -74,6 +89,12 @@ void Squid::minionPhysics() { }
 /* ******************************************** */
 
 void Squid::collisionWithPlayer(bool TOP) {
+
+	if(CCore::getMap()->getPlayer()->getStarEffect()) {
+
+		setMinionState(-2);
+	}
+
 	CCore::getMap()->playerDeath(true, false);
 }
 
@@ -88,4 +109,14 @@ void Squid::changeBlockID() {
 			this->iHitBoxY = 28;
 			break;
 	}
+}
+
+void Squid::setMinionState(int minionState) {
+	this->minionState = minionState;
+
+	if (this->minionState == 1) {
+		deadTime = SDL_GetTicks();
+	}
+
+	Minion::setMinionState(minionState);
 }

--- a/uNext/Squid.h
+++ b/uNext/Squid.h
@@ -20,6 +20,7 @@ public:
 	void collisionWithPlayer(bool TOP);
 
 	void changeBlockID();
+	void setMinionState(int);
 };
 
 #endif


### PR DESCRIPTION
I'm replacing the Nintendo assets with FOSS assets but what I'm using for a goomba
isn't symmetrical like the goomba. Because of this when the goomba moves towards the right , it looks
like it's walking backwards. This changes the direction the gommba is drawn.
I know this change isn't necessary for the symmetrical goomba but it makes
the code more generic. 